### PR TITLE
Fix invalid path when modifying query params

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -29,7 +29,7 @@ function updateUrl(state, defaultState) {
             diff[key] = state[key].toString();
         }
     }
-    window.history.replaceState(null, "", "/?" + new URLSearchParams(diff).toString());
+    window.history.replaceState(null, "", "?" + new URLSearchParams(diff).toString());
 }
 window.onload = function () {
     var ytLink = getElementByIdOrDie("yt-link");

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -43,7 +43,7 @@ function updateUrl(state: State, defaultState: State) {
             diff[key] = state[key].toString();
         }
     }
-    window.history.replaceState(null, "", "/?"+new URLSearchParams(diff).toString())
+    window.history.replaceState(null, "", "?" + new URLSearchParams(diff).toString());
 }
 
 window.onload = () => {


### PR DESCRIPTION
When going on https://tsoding.github.io/thumbnail/ and trying to modify query params, `/thumbnail/` is stripped and we go to https://tsoding.github.io/?width=120 instead.

You can also replicate this by going one folder above the `thumbnail` repo and using `http-server` then navigating to the thumbnail repo.